### PR TITLE
90% - TENT-1522-ExportAsCsvForLCNMigrationJob

### DIFF
--- a/src/echoclient/EchoClient.php
+++ b/src/echoclient/EchoClient.php
@@ -131,16 +131,17 @@ class EchoClient
     }
 
     /**
-     * @param null $class
-     * @param null $key
-     * @param null $value
+     * @param string $class
+     * @param string $key
+     * @param mixed $value
      * @param int $limit
      * @param int $offset
-     * @param null $format
+     * @param string $format
      * @throws \Exception
-     * @return array
+     * @return array|string - an array if the response is json, otherwise a string
      */
-    public function getEvents($class=null, $key=null, $value=null, $limit=25, $offset=0, $format=null){
+    public function getEvents($class=null, $key=null, $value=null, $limit=25, $offset=0, $format=null)
+    {
         if (!empty($class))
         {
             $class = ECHO_CLASS_PREFIX.$class;
@@ -227,10 +228,10 @@ class EchoClient
 
     /**
      * Get hits analytics from echo
-     * @param $class
-     * @param $opts optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
+     * @param string $class
+     * @param array $opts (optional) params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
      *
-     * @return mixed
+     * @return array|string
      * @throws \Exception
      */
     public function getHits($class, $opts = array(), $noCache = false)
@@ -240,10 +241,10 @@ class EchoClient
 
     /**
      * Get sum analytics from echo
-     * @param $class
-     * @param $opts optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
+     * @param string $class
+     * @param array $opts (optional) params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
      *
-     * @return mixed
+     * @return array|string
      * @throws \Exception
      */
     public function getSum($class, $opts = array())
@@ -253,10 +254,10 @@ class EchoClient
 
     /**
      * Get max analytics from echo
-     * @param $class
-     * @param $opts optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
+     * @param string $class
+     * @param array $opts (optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
      *
-     * @return mixed
+     * @return array|string
      * @throws \Exception
      */
     public function getMax($class, $opts = array())
@@ -266,10 +267,10 @@ class EchoClient
 
     /**
      * Get average analytics from echo
-     * @param $class
-     * @param $opts optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
+     * @param string $class
+     * @param array $opts (optional) params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
      *
-     * @return mixed
+     * @return array|string
      * @throws \Exception
      */
     public function getAverage($class, $opts = array())
@@ -281,7 +282,7 @@ class EchoClient
      * @param $class
      * @param $type
      * @param array $opts optional params as per the echo docs @ http://docs.talisecho.apiary.io/#analytics
-     * @return mixed
+     * @return array|string an array if the result is json, otherwise a string
      * @throws \Exception
      */
     protected function getAnalytics($class,$type,$opts=array(),$noCache = false)

--- a/src/echoclient/EchoClient.php
+++ b/src/echoclient/EchoClient.php
@@ -127,6 +127,20 @@ class EchoClient
      */
     public function getRecentEvents($class=null, $key=null, $value=null, $limit=25)
     {
+       return $this->getEvents($class, $key, $value, $limit);
+    }
+
+    /**
+     * @param null $class
+     * @param null $key
+     * @param null $value
+     * @param int $limit
+     * @param int $offset
+     * @param null $format
+     * @throws \Exception
+     * @return array
+     */
+    public function getEvents($class=null, $key=null, $value=null, $limit=25, $offset=0, $format=null){
         if (!empty($class))
         {
             $class = ECHO_CLASS_PREFIX.$class;
@@ -141,19 +155,34 @@ class EchoClient
             return false;
         }
 
-        $eventUrl = $baseUrl.'/events?limit='.$limit;
+        $eventUrl = $baseUrl.'/events?';
+        $params = array();
+        if (!empty($limit))
+        {
+            $params['limit'] = $limit;
+        }
+        if (!empty($offset))
+        {
+            $params['offset'] = $offset;
+        }
         if (!empty($class))
         {
-            $eventUrl .= '&class='.urlencode($class);
+            $params['class'] = $class;
         }
         if (!empty($key))
         {
-            $eventUrl .= '&key='.urlencode($key);
+            $params['key'] = $key;
         }
         if (!empty($value))
         {
-            $eventUrl .= '&value='.urlencode($value);
+            $params['value'] = $value;
         }
+        if (!empty($format))
+        {
+            $params['format'] = $format;
+        }
+
+        $eventUrl .= http_build_query($params);
 
         try
         {
@@ -163,12 +192,22 @@ class EchoClient
 
             if ($response->isSuccessful())
             {
-                $result = json_decode($response->getBody(true),true);
-                if (isset($result['events']))
-                {
-                    $this->getLogger()->debug('Success getting events from echo - '.$class);
-                    return $result['events'];
+                switch($format){
+                    case "csv":
+                        $result = $response->getBody(true);
+                        if($result){
+                            return $result;
+                        }
+                        break;
+                    default:
+                        $result = json_decode($response->getBody(true),true);
+                        if (isset($result['events']))
+                        {
+                            $this->getLogger()->debug('Success getting events from echo - '.$class);
+                            return $result['events'];
+                        }
                 }
+
                 $this->getLogger()->warning('Failed getting events from echo - '.$class, array('responseCode'=>$response->getStatusCode(), 'responseBody'=>$response->getBody(true)));
                 throw new \Exception("Failed getting events from echo, could not decode response");
             }
@@ -181,7 +220,7 @@ class EchoClient
         catch (\Exception $e)
         {
             // For any exception issue, just log the issue and fail silently.  E.g. failure to connect to echo server, or whatever.
-            $this->getLogger()->warning('Failed sending event to echo - '.$class, array('exception'=>get_class($e), 'message'=>$e->getMessage()));
+            $this->getLogger()->warning('Failed getting events from echo - '.$class, array('exception'=>get_class($e), 'message'=>$e->getMessage()));
             throw $e;
         }
     }
@@ -194,9 +233,9 @@ class EchoClient
      * @return mixed
      * @throws \Exception
      */
-    public function getHits($class, $opts = array())
+    public function getHits($class, $opts = array(), $noCache = false)
     {
-        return $this->getAnalytics($class,self::ECHO_ANALYTICS_HITS,$opts);
+        return $this->getAnalytics($class,self::ECHO_ANALYTICS_HITS,$opts, $noCache);
     }
 
     /**
@@ -245,7 +284,7 @@ class EchoClient
      * @return mixed
      * @throws \Exception
      */
-    protected function getAnalytics($class,$type,$opts=array())
+    protected function getAnalytics($class,$type,$opts=array(),$noCache = false)
     {
         $class = ECHO_CLASS_PREFIX.$class;
 
@@ -272,21 +311,31 @@ class EchoClient
         }
 
         $client = $this->getHttpClient();
-        $request = $client->get($eventUrl, $this->getHeaders(), array('connect_timeout'=>10));
+        $request = $client->get($eventUrl, $this->getHeaders($noCache), array('connect_timeout'=>10));
         $response = $request->send();
 
         if ($response->isSuccessful())
         {
             $this->getLogger()->debug('Success getting analytics from echo - '.$type, $opts);
-            $json = json_decode($response->getBody(true),true);
-            if ($json)
-            {
-                return $json;
-            }
-            else
-            {
-                $this->getLogger()->warning('Failed getting analytics from echo, json did not decode - '.$class, array('body'=>$response->getBody(true),'responseCode'=>$response->getStatusCode(), 'responseBody'=>$response->getBody(true), 'requestClass'=>$class, 'requestType'=>$type, 'requestOpts'=>$opts));
-                throw new \Exception("Could not get analytics from echo, json did not decode: ".$response->getBody(true));
+            $format = isset($opts['format']) ? $opts["format"] : 'json';
+            switch($format){
+                case "csv":
+                    $result = $response->getBody(true);
+                    if($result){
+                        return $result;
+                    }
+                    break;
+                default:
+                    $json = json_decode($response->getBody(true),true);
+                    if ($json)
+                    {
+                        return $json;
+                    }
+                    else
+                    {
+                        $this->getLogger()->warning('Failed getting analytics from echo, json did not decode - '.$class, array('body'=>$response->getBody(true),'responseCode'=>$response->getStatusCode(), 'responseBody'=>$response->getBody(true), 'requestClass'=>$class, 'requestType'=>$type, 'requestOpts'=>$opts));
+                        throw new \Exception("Could not get analytics from echo, json did not decode: ".$response->getBody(true));
+                    }
             }
         }
         else
@@ -349,7 +398,7 @@ class EchoClient
      * Setup the header array for any request to echo
      * @return array
      */
-    protected function getHeaders()
+    protected function getHeaders($noCache = false)
     {
         $arrPersonaToken = $this->getPersonaClient()->obtainNewToken(OAUTH_USER, OAUTH_SECRET);
         $personaToken = $arrPersonaToken['access_token'];
@@ -358,6 +407,10 @@ class EchoClient
             'Content-Type'=>'application/json',
             'Authorization'=>'Bearer '.$personaToken
         );
+
+        if($noCache){
+            $headers['Cache-Control'] = 'none';
+        }
 
         return $headers;
     }

--- a/test/unit/EchoClientTest.php
+++ b/test/unit/EchoClientTest.php
@@ -101,7 +101,9 @@ class EchoClientTest extends PHPUnit_Framework_TestCase
     {
         $this->setRequiredDefines();
 
-        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient = $this->getMockBuilder('\Talis\Persona\Client\Tokens')
+            ->disableOriginalConstructor()
+            ->getMock();
         $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
 
         $expectedEvent = array("class"=>"test.expected.event");
@@ -160,7 +162,7 @@ class EchoClientTest extends PHPUnit_Framework_TestCase
         $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
         $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
 
-        $expectedResult = "a,csv,file\nwith,some,data";
+        $expectedResult = "\"a\",\"csv\",\"file\"\n\"with\",\"some,\"data\"";
         $response = new \Guzzle\Http\Message\Response('200');
         $response->setBody($expectedResult);
 

--- a/test/unit/EchoClientTest.php
+++ b/test/unit/EchoClientTest.php
@@ -97,6 +97,88 @@ class EchoClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array($expectedEvent),$result);
     }
 
+    function testGetEvents()
+    {
+        $this->setRequiredDefines();
+
+        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
+
+        $expectedEvent = array("class"=>"test.expected.event");
+        $response = new \Guzzle\Http\Message\Response('200');
+        $response->setBody(json_encode(array("events"=>array(
+            $expectedEvent
+        ))));
+
+        $mockRequest = $this->getMock('\Guzzle\Http\Message\Request', array('send'), array('get',''));
+        $mockRequest->expects($this->once())->method('send')->will($this->returnValue($response));
+
+        $stubHttpClient = $this->getMock('\Guzzle\Http\Client', array('get'));
+        $stubHttpClient->expects($this->once())->method('get')->with('http://example.com:3002/1/events?limit=25&class=test.expected.event&key=foo&value=bar')->will($this->returnValue($mockRequest));
+
+        $echoClient = $this->getMock('\echoclient\EchoClient', array('getPersonaClient', 'getHttpClient'));
+        $echoClient->expects($this->once())->method('getPersonaClient')->will($this->returnValue($stubPersonaClient));
+        $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
+
+        $result = $echoClient->getEvents("expected.event","foo","bar");
+
+        $this->assertEquals(array($expectedEvent),$result);
+    }
+
+    function testGetEventsOffset()
+    {
+        $this->setRequiredDefines();
+
+        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
+
+        $expectedEvent = array("class"=>"test.expected.event");
+        $response = new \Guzzle\Http\Message\Response('200');
+        $response->setBody(json_encode(array("events"=>array(
+            $expectedEvent
+        ))));
+
+        $mockRequest = $this->getMock('\Guzzle\Http\Message\Request', array('send'), array('get',''));
+        $mockRequest->expects($this->once())->method('send')->will($this->returnValue($response));
+
+        $stubHttpClient = $this->getMock('\Guzzle\Http\Client', array('get'));
+        $stubHttpClient->expects($this->once())->method('get')->with('http://example.com:3002/1/events?limit=25&offset=30&class=test.expected.event&key=foo&value=bar')->will($this->returnValue($mockRequest));
+
+        $echoClient = $this->getMock('\echoclient\EchoClient', array('getPersonaClient', 'getHttpClient'));
+        $echoClient->expects($this->once())->method('getPersonaClient')->will($this->returnValue($stubPersonaClient));
+        $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
+
+        $result = $echoClient->getEvents("expected.event","foo","bar",25,30);
+
+        $this->assertEquals(array($expectedEvent),$result);
+    }
+
+    function testGetEventsCsvFormat()
+    {
+        $this->setRequiredDefines();
+
+        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
+
+        $expectedResult = "a,csv,file\nwith,some,data";
+        $response = new \Guzzle\Http\Message\Response('200');
+        $response->setBody($expectedResult);
+
+        $mockRequest = $this->getMock('\Guzzle\Http\Message\Request', array('send'), array('get',''));
+        $mockRequest->expects($this->once())->method('send')->will($this->returnValue($response));
+
+        $stubHttpClient = $this->getMock('\Guzzle\Http\Client', array('get'));
+        $stubHttpClient->expects($this->once())->method('get')->with('http://example.com:3002/1/events?limit=25&offset=1000&class=test.expected.event&key=foo&value=bar&format=csv')->will($this->returnValue($mockRequest));
+
+        $echoClient = $this->getMock('\echoclient\EchoClient', array('getPersonaClient', 'getHttpClient'));
+        $echoClient->expects($this->once())->method('getPersonaClient')->will($this->returnValue($stubPersonaClient));
+        $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
+
+        $result = $echoClient->getEvents("expected.event","foo","bar",25,1000,'csv');
+
+        $this->assertEquals($expectedResult,$result);
+    }
+
     function testHitsReturnsExpectedJSON()
     {
         $this->setRequiredDefines();
@@ -118,6 +200,65 @@ class EchoClientTest extends PHPUnit_Framework_TestCase
         $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
 
         $result = $echoClient->getHits('player.view');
+
+        $this->assertTrue(isset($result['head']));
+        $this->assertTrue(isset($result['results']));
+    }
+
+    function testHitsReturnsExpectedCsv()
+    {
+        $this->setRequiredDefines();
+
+        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
+
+        $expectedResponse = "here,are,some,headers\n,and,here,is,some,data";
+        $response = new \Guzzle\Http\Message\Response('200');
+        $response->setBody($expectedResponse);
+
+        $mockRequest = $this->getMock('\Guzzle\Http\Message\Request', array('send'), array('get',''));
+        $mockRequest->expects($this->once())->method('send')->will($this->returnValue($response));
+
+        $stubHttpClient = $this->getMock('\Guzzle\Http\Client', array('get'));
+        $stubHttpClient->expects($this->once())->method('get')->with('http://example.com:3002/1/analytics/hits?class=test.player.view&format=csv')->will($this->returnValue($mockRequest));
+
+        $echoClient = $this->getMock('\echoclient\EchoClient', array('getPersonaClient', 'getHttpClient'));
+        $echoClient->expects($this->once())->method('getPersonaClient')->will($this->returnValue($stubPersonaClient));
+        $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
+
+        $result = $echoClient->getHits('player.view',array('format'=>'csv'));
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    function testHitsReturnsExpectedJSONNoCache()
+    {
+        $this->setRequiredDefines();
+
+        $stubPersonaClient = $this->getMock('\Talis\Persona\Client\Tokens', array(), array(), '', false);
+        $stubPersonaClient->expects($this->once())->method('obtainNewToken')->will($this->returnValue(array('access_token'=>'some-token')));
+
+        $response = new \Guzzle\Http\Message\Response('200');
+        $response->setBody('{"head":{"type":"hits","class":"test.player.view","group_by":"source","count":27},"results":[{"source":"web.talis-com.b50367b.2014-05-15","hits":45},{"source":"web.talis-com.b692220.2014-05-15","hits":9},{"source":"mobile.android-v1.9","hits":16},{"source":"web.talis-com.f1afa4f.2014-05-13","hits":21},{"source":"mobile.android-v1.7","hits":48},{"source":"web.talis-com.d165ea5.2014-05-01","hits":411},{"source":"web.talis-com.3dceffd.2014-05-15","hits":8},{"source":"mobile.android-v1.6","hits":41},{"source":"web.talis-com.35baf27.2014-04-29","hits":50},{"source":"web.talis-com.13f1318.2014-05-14","hits":18},{"source":"web.talis-com.no-release","hits":219},{"source":"mobile.iOS-v1.97","hits":5},{"source":"web.talis-com-no-release","hits":23},{"source":"web.talis-com.12f4d8c.2014-04-29","hits":29},{"source":"web.talis-com.4a51b66.2014-04-25","hits":56},{"source":"mobile.android-v1.3","hits":4},{"source":"mobile.android-v2.0","hits":39},{"source":"web.talis-com.9df593e.2014-04-17","hits":44},{"source":"web.talis-com.8dac333.2014-04-17","hits":1},{"source":"mobile.iOS-v1.99","hits":60},{"source":"mobile.iOS-v1.98","hits":116},{"source":"web.talis-com.d5e099c.2014-05-15","hits":2},{"source":"mobile.android-v1.8","hits":16},{"source":"web.talis-com.64ade28.2014-04-17","hits":22},{"source":"mobile.iOS-v1.95","hits":10},{"source":"mobile.android-v1.4","hits":1},{"source":"mobile.android-v1.5","hits":20}]}');
+
+        $mockRequest = $this->getMock('\Guzzle\Http\Message\Request', array('send'), array('get',''));
+        $mockRequest->expects($this->once())->method('send')->will($this->returnValue($response));
+
+        $stubHttpClient = $this->getMock('\Guzzle\Http\Client', array('get'));
+        $stubHttpClient->expects($this->once())
+            ->method('get')
+            ->with('http://example.com:3002/1/analytics/hits?class=test.player.view', array(
+                'Content-Type'=>'application/json',
+                'Authorization'=>'Bearer '.'some-token',
+                'Cache-Control'=>'none'
+            ))
+            ->will($this->returnValue($mockRequest));
+
+        $echoClient = $this->getMock('\echoclient\EchoClient', array('getPersonaClient', 'getHttpClient'));
+        $echoClient->expects($this->once())->method('getPersonaClient')->will($this->returnValue($stubPersonaClient));
+        $echoClient->expects($this->once())->method('getHttpClient')->will($this->returnValue($stubHttpClient));
+
+        $result = $echoClient->getHits('player.view',array(),true);
 
         $this->assertTrue(isset($result['head']));
         $this->assertTrue(isset($result['results']));


### PR DESCRIPTION
Updating to allow use of the CSV format option as per https://github.com/talis/echo-server/pull/48

* Can specify csv format for getEvents and getHits
* Limit is no longer required
* Added ``getEvents()`` method to handle the above, so as to preserve the behaviour of ``getRecentEvents()``
* Added the ability to pass a ``$noCache`` param to getHits() so that it will pass a ``Cache-Control: none`` header to echo.
